### PR TITLE
Fix non-UTF-8 characters segfault

### DIFF
--- a/fmenu-rofi
+++ b/fmenu-rofi
@@ -64,7 +64,9 @@ do
 done
 
 function index_files {
-    find "$INPUT" \( ! -regex "$EXCLUDE" \) | sed 's/ /\\ /g' | sort -f > "$INDEX"
+    find "$INPUT" \( ! -regex "$EXCLUDE" \) | sed 's/ /\\ /g' | sort -f > "$INDEX.raw"
+    iconv -f utf-8 -t utf-8 -c "$INDEX.raw" -o "$INDEX"
+    rm "$INDEX.raw"
 }
 
 if [[ ! -a "$INDEX" ]] ||  ( test `find $INDEX -mmin $TIME` ) || ($FORCE)

--- a/fmenu-rofi
+++ b/fmenu-rofi
@@ -26,6 +26,7 @@ TIME="+5"
 INPUT=$HOME
 EXCLUDE='.*/\..*'
 DRY=false
+SHIFT=0
 while getopts "ht:fd:o:i:x:u" OPTION
 do
      case $OPTION in
@@ -35,33 +36,41 @@ do
              ;;
          f)
              FORCE=true
+             SHIFT=$((SHIFT + 1))
              ;;
          d)
              DMENU=$OPTARG
+             SHIFT=$((SHIFT + 2))
              ;;
          t)
              TIME=$OPTARG
+             SHIFT=$((SHIFT + 2))
              ;;
          o)
              INDEX=$OPTARG
+             SHIFT=$((SHIFT + 2))
              ;;
          i)
              INPUT=$OPTARG
+             SHIFT=$((SHIFT + 2))
              ;;
          x)
              EXCLUDE=$OPTARG
+             SHIFT=$((SHIFT + 2))
              ;;
          u)
              FORCE=true
              DRY=true
+             SHIFT=$((SHIFT + 1))
              ;;
          ?)
              usage
              exit
              ;;
      esac
-     shift 1
 done
+
+shift $SHIFT
 
 function index_files {
     find "$INPUT" \( ! -regex "$EXCLUDE" \) | sed 's/ /\\ /g' | sort -f > "$INDEX.raw"

--- a/fmenu-rofi
+++ b/fmenu-rofi
@@ -16,6 +16,7 @@ OPTIONS:
    -f      force reloading index [default: false]
    -t      time [default: 5min]
    -u      Just update the index
+   -n      Prevent it from building the index
 EOF
 }
 
@@ -26,8 +27,9 @@ TIME="+5"
 INPUT=$HOME
 EXCLUDE='.*/\..*'
 DRY=false
+BUILD_INDEX=true
 SHIFT=0
-while getopts "ht:fd:o:i:x:u" OPTION
+while getopts "ht:fd:o:i:x:un" OPTION
 do
      case $OPTION in
          h)
@@ -63,6 +65,10 @@ do
              DRY=true
              SHIFT=$((SHIFT + 1))
              ;;
+         n)
+             BUILD_INDEX=false
+             SHIFT=$((SHIFT + 1))
+             ;;
          ?)
              usage
              exit
@@ -78,16 +84,22 @@ function index_files {
     rm "$INDEX.raw"
 }
 
-if [[ ! -a "$INDEX" ]] ||  ( test `find $INDEX -mmin $TIME` ) || ($FORCE)
+if ( $BUILD_INDEX )
 then
-    index_files
+    if [[ ! -a "$INDEX" ]] ||  ( test `find $INDEX -mmin $TIME` ) || ($FORCE)
+    then
+        index_files
+    fi
 fi
 
 if ( ! $DRY )
 then
     if [ -z $@ ]
     then
-        cat "$INDEX"
+        if [[ -a "$INDEX" ]]
+        then
+            cat "$INDEX"
+        fi
     else
         xdg-open $@ > /dev/null &
     fi


### PR DESCRIPTION
Basic fix for https://github.com/dbordak/fmenu-rofi/issues/2. Just call "iconv" to discard such characters in the index file.
